### PR TITLE
修复omni自动脚本破解错误

### DIFF
--- a/config.json
+++ b/config.json
@@ -117,7 +117,8 @@
     {
       "packageName": "com.mac.utility.screen.recorder",
       "bridgeFile": "/Contents/MacOS/",
-      "injectFile": "OmniRecorder"
+      "injectFile": "OmniRecorder",
+      "extraShell": "omni-recorder.sh"
     },{
       "packageName": [
         "com.seriflabs.affinityphoto2",

--- a/tool/omni-recorder.sh
+++ b/tool/omni-recorder.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+OMNI_DIR="/Applications/OmniRecorder.app"
+
+LIBDOBBY_SRC_DIR="${OMNI_DIR}/Contents/MacOS/libdobby.dylib"
+LIBDOBBY_DST_DIR="${OMNI_DIR}/Contents/Frameworks/libdobby.dylib"
+
+mv ${LIBDOBBY_SRC_DIR} ${LIBDOBBY_DST_DIR}
+
+echo "已移动 libdobby.dylib 到: ${OMNI_DIR}/Contents/Frameworks"


### PR DESCRIPTION
修复因libdobby.dylib位置错误造成的自动脚本破解错误。

问题根源：目前的注入程序会将libdobby.dylib文件放在config.json的bridgeFile路径下。而libdobby.dylib正常工作需要在Contents/Frameworks下。若bridgeFile路径不是Contents/Frameworks，则会出错。 

暂时解决方案（本pr）：使用了一个外挂脚本omni-recorder.sh在注入完成后将libdobby文件移动到正确的位置。 

建议：修复libdobby.dylib只能在Contents/Frameworks下工作的问题，或修复注入工具无法将libdobby文件放置在异于待破解二进制文件目录（bridgeFile）的问题